### PR TITLE
Replaced reserved variable names

### DIFF
--- a/_layouts/work.html
+++ b/_layouts/work.html
@@ -2,8 +2,8 @@
 layout: default
 ---
 <nav class="quick-nav" role="navigation">
-    <a href="/work/{{ page.previous }}"><i class="icon-left"></i></a>
+    <a href="/work/{{ page.backward }}"><i class="icon-left"></i></a>
     <a href="/work/"><i class="icon-th"></i></a>
-    <a href="/work/{{ page.next }}"><i class="icon-right"></i></a>
+    <a href="/work/{{ page.forward }}"><i class="icon-right"></i></a>
 </nav>
 {{ content }}

--- a/_work/bookmooch-social-networking-survey.md
+++ b/_work/bookmooch-social-networking-survey.md
@@ -3,8 +3,8 @@ layout: work
 navigation: horizontal
 title: BookMooch Social Networking Survey - Andrew Pucci
 description: Portfolio piece showing how a set of surveys was completed for BookMooch.
-previous: young-professionals-of-akron-usability-study
-next: visual-design-of-telerik-analytics
+backward: young-professionals-of-akron-usability-study
+forward: visual-design-of-telerik-analytics
 ---
 # BookMooch Social Networking Survey
 ![BookMooch Social Networking Survey](/img/bookmooch-survey.png)

--- a/_work/carnation-city-mall-blueprints.md
+++ b/_work/carnation-city-mall-blueprints.md
@@ -3,8 +3,8 @@ layout: work
 navigation: horizontal
 title: Carnation City Mall Blueprints - Andrew Pucci
 description: Portfolio piece showing how blueprints were created for Carnation City Mall.
-previous: revamping-course-registration
-next: local-yokel-foods-paper-prototype
+backward: revamping-course-registration
+forward: local-yokel-foods-paper-prototype
 ---
 # Carnation City Mall Blueprints
 ![Carnation City Mall Blueprints](/img/carnation-blueprint.png)

--- a/_work/improving-telerik-product-documentation.md
+++ b/_work/improving-telerik-product-documentation.md
@@ -3,8 +3,8 @@ layout: work
 navigation: horizontal
 title: Improving Telerik Product Documentation - Andrew Pucci
 description: Portfolio piece showing how Telerik product documentation was improved with interviews.
-previous: visual-design-of-telerik-analytics
-next: lunchboat-mobile-app-interaction-flow
+backward: visual-design-of-telerik-analytics
+forward: lunchboat-mobile-app-interaction-flow
 ---
 # Improving Telerik Product Documentation
 ![Improving Telerik Product Documentation](/img/kendoui-docs.png)

--- a/_work/local-yokel-foods-paper-prototype.md
+++ b/_work/local-yokel-foods-paper-prototype.md
@@ -3,8 +3,8 @@ layout: work
 navigation: horizontal
 title: Local Yokel Foods Paper Prototype - Andrew Pucci
 description: Portfolio piece showing how a paper prototype was used to improve the Local Yokel Foods website.
-previous: carnation-city-mall-blueprints
-next: young-professionals-of-akron-usability-study
+backward: carnation-city-mall-blueprints
+forward: young-professionals-of-akron-usability-study
 ---
 # Local Yokel Foods Paper Prototype
 ![Local Yokel Foods Paper Prototype](/img/paper-prototype.png)

--- a/_work/lunchboat-mobile-app-interaction-flow.md
+++ b/_work/lunchboat-mobile-app-interaction-flow.md
@@ -3,8 +3,8 @@ layout: work
 navigation: horizontal
 title: LunchBoat Mobile App Interaction Flow  - Andrew Pucci
 description: Portfolio piece showing the ideation process for the LunchBoat mobile app.
-previous: improving-telerik-product-documentation
-next: understanding-justcode-users
+backward: improving-telerik-product-documentation
+forward: understanding-justcode-users
 ---
 # LunchBoat Mobile App Interaction Flow
 ![LunchBoat Mobile App Interaction Flow](/img/lunchboat-interactionflow.png)

--- a/_work/revamping-course-registration.md
+++ b/_work/revamping-course-registration.md
@@ -3,8 +3,8 @@ layout: work
 navigation: horizontal
 title: Revamping Course Registration  - Andrew Pucci
 description: Portfolio piece showing the process used to revamp academic course registration.
-previous: understanding-justcode-users
-next: carnation-city-mall-blueprints
+backward: understanding-justcode-users
+forward: carnation-city-mall-blueprints
 ---
 # Revamping Course Registration
 ![Revamping Course Registration](/img/course-selection.png)

--- a/_work/understanding-justcode-users.md
+++ b/_work/understanding-justcode-users.md
@@ -3,8 +3,8 @@ layout: work
 navigation: horizontal
 title: Understanding JustCode Users - Andrew Pucci
 description: Portfolio piece showing how surveys and interviews were used to understand JustCode users.
-previous: lunchboat-mobile-app-interaction-flow
-next: revamping-course-registration
+backward: lunchboat-mobile-app-interaction-flow
+forward: revamping-course-registration
 ---
 # Understanding JustCode Users
 ![Understanding JustCode Users](/img/improving-justcode.png)

--- a/_work/visual-design-of-telerik-analytics.md
+++ b/_work/visual-design-of-telerik-analytics.md
@@ -3,8 +3,8 @@ layout: work
 navigation: horizontal
 title: Visual Design of Telerik Analytics - Andrew Pucci
 description: Portfolio piece showing the process used to design Telerik Analytics.
-previous: bookmooch-social-networking-survey
-next: improving-telerik-product-documentation
+backward: bookmooch-social-networking-survey
+forward: improving-telerik-product-documentation
 ---
 # Visual Design of Telerik Analytics
 ![Visual Design of Telerik Analytics](/img/analytics-design.png)

--- a/_work/young-professionals-of-akron-usability-study.md
+++ b/_work/young-professionals-of-akron-usability-study.md
@@ -3,8 +3,8 @@ layout: work
 navigation: horizontal
 title: Young Professionals of Akron Usability Study - Andrew Pucci
 description: Portfolio piece showing how eye-tracking was used to improve the Young Professionals of Akron website.
-previous: local-yokel-foods-paper-prototype
-next: bookmooch-social-networking-survey
+backward: local-yokel-foods-paper-prototype
+forward: bookmooch-social-networking-survey
 ---
 # Young Professionals of Akron Usability Study
 ![Young Professionals of Akron Usability Study](/img/ypa-eyetracking.png)


### PR DESCRIPTION
page.next and page.forward are now reserved variable names in Jekyll
3.4.0. Replaced them with page.previous and page.backward,
respectively. Might want to look into newly available functionality to
create this nav in a way that makes more sense and is less manual.