### PR TITLE
Allow connect and object from self

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,9 +24,9 @@
       style-src 'self';
       img-src 'self' data:;
       font-src 'self';
-      connect-src 'none';
+      connect-src 'self';
       media-src 'none';
-      object-src 'none';
+      object-src 'self';
       prefetch-src 'self';
       frame-src 'none';
       worker-src 'none';


### PR DESCRIPTION
Due to https://answers.netlify.com/t/setting-response-headers-only-on-documents/6144 it's not possible to set headers only on documents, so these changes should help stop CSP from blocking .txt, .pdf, and .png files