### PR TITLE
Add agent skills configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,27 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
+
 This repository is an Eleventy v3 static site. Authoring source lives in `src/site/`, with shared data in `src/site/_data/`, layouts in `src/site/_layouts/`, reusable partials in `src/site/_includes/`, and Sass in `src/site/assets/styles/`. Custom Eleventy logic lives in `src/utils/` for filters, shortcodes, image helpers, and minification. Tests are split between `tests/unit/` for Vitest coverage and `tests/e2e/` for Playwright flows. Build output goes to `dist/` and should be treated as generated.
 
 ## Build, Test, and Development Commands
+
 Use `npm ci` to install dependencies. Run `npm run dev` for the local Eleventy server with a clean rebuild and live reload on `http://localhost:8080`. Use `npm run prod` for a production build and `npm run serve` to serve the current build without rebuilding. `npm test` runs the CI-style unit test and lint pass. `npm run test:e2e` runs Playwright against the local site, and `npm run test:ci` runs the full local validation path.
 
 ## Coding Style & Naming Conventions
+
 This is an ESM-only codebase; use `import`/`export`, not CommonJS. Formatting is enforced with `oxfmt`, and linting uses `oxlint`; run `npm run lint:fix` before opening a PR. Keep JavaScript, Nunjucks, and Markdown changes small and readable. Match existing file patterns such as `*.test.js` for unit tests, `*.spec.js` for E2E, and resume entries like `src/site/resume/entries/work/2022-expel-senior-ux-designer.md`.
 
 ## Testing Guidelines
+
 Unit tests run with Vitest and `happy-dom`; E2E coverage uses Playwright. Maintain the existing 80% coverage threshold for lines, functions, branches, and statements with `npm run test:coverage`. Add or update unit tests when touching `src/utils/` or site data logic, and add E2E tests for navigation, page structure, or other visitor-facing behavior.
 
 ## Commit & Pull Request Guidelines
+
 Recent history favors short, imperative commit messages, often with a prefix like `fix:` or `refactor:` and an issue or PR reference when relevant. Keep commits focused and explain user-visible changes in the PR description. Link the related issue, note any environment or content migrations, and include screenshots for layout or styling changes. Before requesting review, run `npm run test:ci`.
 
 ## Configuration & Content Notes
+
 Copy `.env-sample` to `.env` and set `ROOT_URL` before local development or E2E testing. Do not commit secrets. When adding portfolio or resume content, prefer editing Markdown in `src/site/portfolio/` or `src/site/resume/entries/` rather than generated output.
 
 ## Agent skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This repository is an Eleventy v3 static site. Authoring source lives in `src/site/`, with shared data in `src/site/_data/`, layouts in `src/site/_layouts/`, reusable partials in `src/site/_includes/`, and Sass in `src/site/assets/styles/`. Custom Eleventy logic lives in `src/utils/` for filters, shortcodes, image helpers, and minification. Tests are split between `tests/unit/` for Vitest coverage and `tests/e2e/` for Playwright flows. Build output goes to `dist/` and should be treated as generated.
+
+## Build, Test, and Development Commands
+Use `npm ci` to install dependencies. Run `npm run dev` for the local Eleventy server with a clean rebuild and live reload on `http://localhost:8080`. Use `npm run prod` for a production build and `npm run serve` to serve the current build without rebuilding. `npm test` runs the CI-style unit test and lint pass. `npm run test:e2e` runs Playwright against the local site, and `npm run test:ci` runs the full local validation path.
+
+## Coding Style & Naming Conventions
+This is an ESM-only codebase; use `import`/`export`, not CommonJS. Formatting is enforced with `oxfmt`, and linting uses `oxlint`; run `npm run lint:fix` before opening a PR. Keep JavaScript, Nunjucks, and Markdown changes small and readable. Match existing file patterns such as `*.test.js` for unit tests, `*.spec.js` for E2E, and resume entries like `src/site/resume/entries/work/2022-expel-senior-ux-designer.md`.
+
+## Testing Guidelines
+Unit tests run with Vitest and `happy-dom`; E2E coverage uses Playwright. Maintain the existing 80% coverage threshold for lines, functions, branches, and statements with `npm run test:coverage`. Add or update unit tests when touching `src/utils/` or site data logic, and add E2E tests for navigation, page structure, or other visitor-facing behavior.
+
+## Commit & Pull Request Guidelines
+Recent history favors short, imperative commit messages, often with a prefix like `fix:` or `refactor:` and an issue or PR reference when relevant. Keep commits focused and explain user-visible changes in the PR description. Link the related issue, note any environment or content migrations, and include screenshots for layout or styling changes. Before requesting review, run `npm run test:ci`.
+
+## Configuration & Content Notes
+Copy `.env-sample` to `.env` and set `ROOT_URL` before local development or E2E testing. Do not commit secrets. When adding portfolio or resume content, prefer editing Markdown in `src/site/portfolio/` or `src/site/resume/entries/` rather than generated output.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues for this repo (`gh` CLI); external PRs are not a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — one `CONTEXT.md` at the repo root plus `docs/adr/` for architectural decisions. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,12 +57,12 @@ Four resume collections are auto-created in `.eleventy.js` from folder name: `wo
 
 ### Custom utilities (`src/utils/`)
 
-| File | Purpose |
-|------|---------|
-| `filters.js` | Nunjucks filters: `dateToFormat` (Luxon), `obfuscate` (HTML entities for emails), `stripSpaces`, `stripProtocol` |
-| `async-shortcodes.js` | Nunjucks async shortcodes: `image`, `card`, `expandableImage` |
-| `image.js` | `@11ty/eleventy-img` wrapper generating WebP + JPEG at multiple widths |
-| `minify.js` | Eleventy transform calling `min-html.js` / `min-js.js` |
+| File                  | Purpose                                                                                                          |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `filters.js`          | Nunjucks filters: `dateToFormat` (Luxon), `obfuscate` (HTML entities for emails), `stripSpaces`, `stripProtocol` |
+| `async-shortcodes.js` | Nunjucks async shortcodes: `image`, `card`, `expandableImage`                                                    |
+| `image.js`            | `@11ty/eleventy-img` wrapper generating WebP + JPEG at multiple widths                                           |
+| `minify.js`           | Eleventy transform calling `min-html.js` / `min-js.js`                                                           |
 
 When adding a filter or shortcode, implement it in the appropriate `src/utils/` file and register it in `.eleventy.js`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Development (updates browserslist db, cleans dist/, builds, and starts live-reload server)
+npm run dev
+
+# Serve without rebuilding (useful when running E2E tests separately)
+npm run serve
+
+# Production build
+npm run prod
+
+# Lint and unit tests (what CI runs first)
+npm test
+
+# Unit tests only in watch mode
+npm run test:watch
+
+# Run a single unit test file
+npx vitest run tests/unit/filters.test.js
+
+# E2E tests (auto-starts dev server on port 8080)
+npm run test:e2e
+
+# Fix lint and formatting issues
+npm run lint:fix
+```
+
+**Required env var**: copy `.env-sample` to `.env` and set `ROOT_URL` to your local or deployed URL (e.g., `http://localhost:8080`).
+
+## Architecture
+
+This is an **Eleventy v3** static site (ESM, `"type": "module"`). Source lives in `src/site/`; build output goes to `dist/`.
+
+### Eleventy config (`.eleventy.js`)
+
+- **Input**: `src/site/`, **Output**: `dist/`
+- **Layouts dir**: `src/site/_layouts/`, **Data dir**: `src/site/_data/`
+- Template formats: Nunjucks (`.njk`) and Markdown (`.md`), both processed through Nunjucks
+- Asset pipeline: `eleventy-sass` compiles Sass → PostCSS (autoprefixer + cssnano) → cache-busted filenames via `eleventy-plugin-rev`
+- HTML/JS minification is an Eleventy transform (`src/utils/minify.js`) that runs after render
+
+### Collections
+
+Four resume collections are auto-created in `.eleventy.js` from folder name: `work`, `education`, `speaking`, `volunteering`. Entries live in `src/site/resume/entries/<name>/` and are sorted by `start` frontmatter (numeric timestamp). The `entries.json` in that folder sets `permalink: false` so entries aren't built as standalone pages.
+
+### Global data (`src/site/_data/`)
+
+- `author.json` — personal info used across templates
+- `cards.json` — portfolio card data for the home page carousel
+- `strings.json` — reusable UI strings
+- `site.js` — exports `rootUrl` from `ROOT_URL` env var
+
+### Custom utilities (`src/utils/`)
+
+| File | Purpose |
+|------|---------|
+| `filters.js` | Nunjucks filters: `dateToFormat` (Luxon), `obfuscate` (HTML entities for emails), `stripSpaces`, `stripProtocol` |
+| `async-shortcodes.js` | Nunjucks async shortcodes: `image`, `card`, `expandableImage` |
+| `image.js` | `@11ty/eleventy-img` wrapper generating WebP + JPEG at multiple widths |
+| `minify.js` | Eleventy transform calling `min-html.js` / `min-js.js` |
+
+When adding a filter or shortcode, implement it in the appropriate `src/utils/` file and register it in `.eleventy.js`.
+
+### Testing
+
+- **Unit tests** (Vitest + happy-dom): test files matching `**/*.test.js` except `tests/e2e/`. Coverage thresholds are 80% across lines/functions/branches/statements.
+- **E2E tests** (Playwright): `tests/e2e/`. Playwright starts `npm run serve` automatically; tests hit `http://localhost:8080` (override with `TEST_BASE_URL`).
+
+### Linting
+
+Uses **oxlint** (not ESLint) with the config in `.oxlintrc.json`, and **oxfmt** for formatting (`.oxfmtrc.json`). ESM-only codebase — `import/no-commonjs` is enforced.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues for this repo (`gh` CLI); external PRs are not a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — one `CONTEXT.md` at the repo root plus `docs/adr/` for architectural decisions. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,34 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
- Add `AGENTS.md` to the repo root so agent-focused tools have a dedicated config file alongside `CLAUDE.md`
- Add an `## Agent skills` block to both `CLAUDE.md` and `AGENTS.md` pointing skills to the new docs
- Add `docs/agents/issue-tracker.md` to configure GitHub Issues as the tracker (via `gh` CLI, external PRs excluded from triage)
- Add `docs/agents/triage-labels.md` with the default five-label triage vocabulary
- Add `docs/agents/domain.md` to declare the single-context layout (`CONTEXT.md` at root, `docs/adr/` for decisions)