### PR TITLE
docs: add domain context and ADRs for SvelteKit/Cloudflare migration

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,43 @@
+# Context: andrewpucci.com
+
+This site is Andrew Pucci's personal portfolio. It's also where the design system that powers it gets built. The two are the same project.
+
+The portfolio makes one argument: a designer who builds things. Andrew is a principal UX designer, an accessibility practitioner, and works in information security. All three roles set the standard for this codebase. The design system architecture, token pipeline, component library, accessibility engineering, and security posture are evidence of that as much as the work on display.
+
+These aren't separate checklists. A polished page that fails a keyboard user fails. An accessible component on a site with weak security hygiene fails. A technically sound implementation with poor information hierarchy fails. The craft holds all three at once.
+
+Any future decision in this repo carries the weight of all three disciplines. Adding a third-party script is a security decision. Introducing a new interactive pattern is an accessibility decision. Changing the information architecture is a UX decision. Treat them that way.
+
+## Domain vocabulary
+
+**Design token.** A named value that carries a design decision. Tokens replace hardcoded values in component styles. This project uses three tiers: base, semantic, and component.
+
+**Base token.** The raw value layer. Named for what the value is, not what it's used for. `color.pink.500 = #d42274`. Nothing in the codebase should reference a base token directly.
+
+**Semantic token.** The role layer. References a primitive by its meaning. `color.brand.primary → color.pink.500`. Components consume semantic tokens.
+
+**Component token.** The usage layer. References a semantic token for a specific component property. `button.primary.background → color.brand.primary`.
+
+**DTCG.** Design Tokens Community Group. A W3C community spec for a standard token JSON format. Hit v1.0 stable in October 2025. Tokens in this project are DTCG-format JSON.
+
+**Terrazzo.** The build tool that takes DTCG token JSON and generates CSS custom properties. Runs as a Vite plugin during the build. Output is a generated CSS file imported in the root layout.
+
+**MDsvex.** A preprocessor that allows Svelte components to be embedded inside Markdown files. Used for portfolio case study pages so that live component demos can appear inline in the case study narrative.
+
+**Story.** A Storybook file that renders a component in a specific state. Stories are the component tests; they contain `play()` interaction assertions that run in CI via Vitest.
+
+**Snapshot.** A Chromatic unit. One story rendered in one browser at one point in time. Used for visual regression: Chromatic compares snapshots across builds and flags changes.
+
+**Scoped styles.** CSS written in a `<style>` block inside a `.svelte` file. SvelteKit scopes them to the component automatically. They sit outside the `@layer` system and win over any layered global style without needing high specificity.
+
+**CSS layer.** A named layer in the `@layer` cascade order. Global styles are organized into explicit layers (`reset`, `tokens`, `base`, `components`, `utilities`) to avoid specificity fights.
+
+**Content component.** A component in `src/lib/` that knows about portfolio data shapes (resume entries, testimonials, portfolio cards) and appears in more than one route. Gets a Storybook story.
+
+**Page section.** A layout element specific to one route. Lives in `src/routes/`, not `src/lib/`. Doesn't get a Storybook story.
+
+**Worker.** A Cloudflare Worker. Handles server-side logic in this otherwise static site. Used for the contact form: receives the POST, validates via a bot protection service, and delivers email via a transactional email provider. Credentials are environment variables in the Cloudflare dashboard.
+
+**Adapter.** SvelteKit's deployment abstraction. This project uses `adapter-cloudflare`, which prerenders all pages at build time and bundles Workers for any server-side routes.
+
+**Precision Pink.** The primary brand color (`#d42274`). The sole saturated color in the palette. Used on active nav states, CTAs, timeline markers, and the full-bleed footer. Everything else is neutral.

--- a/docs/adr/0001-usability-standards.md
+++ b/docs/adr/0001-usability-standards.md
@@ -1,0 +1,61 @@
+# ADR-0001: Usability standards
+
+Date: 2026-06-29
+Status: Accepted
+
+## Context
+
+Andrew is a principal UX designer. The portfolio is an argument for craft; the UX of the site is itself evidence. Usability is a design constraint from the first component, not a checklist item at the end of a build.
+
+The site's primary audience is hiring managers and design leaders evaluating portfolio candidates. They navigate with intention and notice friction immediately. A site that describes good UX but doesn't embody it fails the argument.
+
+The audit of the existing site found failures that existed because no usability standard was applied during the original build: auto-playing carousel with no pause mechanism, color-only nav active states, missing skip-to-content link. These are carried forward as known debt and are P0/P1 items in the new build.
+
+## Decision
+
+### Evaluation framework
+
+Nielsen's 10 usability heuristics are the lens for design review. Every significant new feature gets a usability review at the shape stage, before code, not after. Shape-stage reviews are cheaper to correct and prevent the most common class of rework.
+
+### What is automated
+
+**Lighthouse, run in CI,** enforces the following thresholds on every deployment. Falling below any threshold fails the CI run:
+
+- Performance score ≥ 90
+- LCP ≤ 2.5s (maps to heuristic 1: visibility of system status — a slow response is invisible feedback)
+- CLS ≤ 0.1 (maps to heuristic 4: consistency and standards — layout shifts disrupt the reading context mid-task)
+- INP ≤ 200ms
+- Best Practices score ≥ 90
+- SEO score ≥ 90
+
+**Custom Playwright assertions** check hygiene signals not covered by Lighthouse or axe-core:
+
+- Every page has a descriptive, unique `<title>`
+- Forms preserve user input on failed validation (heuristic 3: user control and freedom)
+- Error messages are present, clearly worded, and associated with their inputs (heuristic 9)
+
+### What requires human judgment
+
+The majority of heuristics require judgment about context, user intent, and mental models that no tool can substitute for:
+
+- Information architecture and task flow coherence
+- Mental model alignment: whether patterns are conventional enough to be learnable without instruction (heuristic 6: recognition rather than recall)
+- Error message clarity and tone beyond structural presence
+- Voice and tone consistency
+- Aesthetic minimalism (heuristic 8)
+- Flexibility for both first-time and returning visitors (heuristic 7)
+
+These are evaluated at the shape stage, not by a CI gate.
+
+## Alternatives considered
+
+**Commercial automated heuristic evaluation tools.** Several tools claim to score UX heuristics automatically. In practice, they produce too many false positives on legitimate patterns and miss the issues that matter most. Not reliable enough as CI gates.
+
+**Deferred usability review after build.** This is how the existing site was built. The known P0/P1 issues are the result. Shape-stage review — heuristic evaluation before code is written — prevents the most expensive class of rework.
+
+## Consequences
+
+- Lighthouse is added to the CI pipeline alongside Vitest and Playwright. See ADR-0010.
+- Custom Playwright assertions run usability hygiene checks on every page route. See ADR-0010.
+- Any PR that regresses a Lighthouse score below threshold fails CI. The metric must recover, or the new threshold must be documented here as an intentional adjustment.
+- No component or pattern is considered done until it has been reviewed against the relevant heuristics. Keyboard navigation and error state behavior are part of that review, covered by ADR-0002.

--- a/docs/adr/0002-accessibility-standards.md
+++ b/docs/adr/0002-accessibility-standards.md
@@ -1,0 +1,67 @@
+# ADR-0002: Accessibility standards
+
+Date: 2026-06-29
+Status: Accepted
+
+## Context
+
+Andrew is an accessibility practitioner. An inaccessible portfolio would directly contradict the argument the site makes. Accessibility is not a compliance pass at the end of a build; it's a design constraint from the first component.
+
+The existing Eleventy site had documented accessibility failures: no skip-to-content link, auto-playing carousel with no pause mechanism (WCAG 2.2.2), missing reduced-motion support in animations, and color-only active states in the nav. These are carried forward as known debt in the current build and are P0/P1 items in the new one.
+
+## Decision
+
+### Conformance target
+
+WCAG 2.2 AA is the floor. AAA criteria are pursued where they don't conflict with design intent.
+
+### Page structure
+
+- Every page includes a skip-to-content link as the first focusable element.
+- Heading hierarchy is enforced: one `h1` per page, no heading levels skipped.
+- Landmark regions (`<main>`, `<nav>`, `<header>`, `<footer>`) are present and labeled where more than one of the same type exists on a page.
+
+### Focus management
+
+- Focus indicators are visible on all interactive elements and meet a 3:1 contrast ratio against adjacent colors (WCAG 1.4.11).
+- Focus order follows the visual reading order.
+- Components that move focus programmatically (modals, drawers, dynamic content) return focus to the trigger on close.
+
+### Motion
+
+- Every animation and transition has a `prefers-reduced-motion: reduce` alternative. The alternative is typically a crossfade or instant transition.
+- No content is gated behind an animation completing. Animated reveals use a visible default state; the motion is enhancement, not a reveal gate.
+- Auto-playing or looping content (carousels, video) includes pause controls that are keyboard-accessible.
+
+### Color and contrast
+
+- Body text: minimum 4.5:1 contrast against its background.
+- Large text (18px regular or 14px bold and above): minimum 3:1.
+- UI components and focus indicators: minimum 3:1.
+- No color-only state communication. Active states, error states, and status indicators use shape, text, or icon in addition to color.
+
+### Semantic markup and ARIA
+
+- Native HTML elements are used where they exist. ARIA is added only when native semantics are insufficient.
+- Interactive components follow ARIA Authoring Practices Guide patterns (menus, dialogs, tabs, accordions).
+- All images have meaningful `alt` text. Decorative images use `alt=""`.
+- Form inputs have visible labels. Error messages are programmatically associated with their inputs.
+
+### Testing
+
+- The Storybook accessibility addon runs on every story. Violations surface in the Storybook UI during development.
+- `@axe-core/playwright` runs in Playwright E2E tests on all page-level routes and fails CI on any violation.
+- Keyboard navigation is manually verified for all interactive patterns before a component is considered complete.
+
+## Alternatives considered
+
+**Automated testing only.** `axe-core` catches roughly 30–40% of WCAG issues automatically. It's a necessary layer, not a sufficient one. Manual keyboard testing and screen reader spot-checks cover what automated tools miss.
+
+**WCAG 2.1 as the target.** 2.2 supersedes 2.1 and adds criteria that matter in practice (focus appearance, drag alternatives, redundant entry). There's no reason to aim at the older version.
+
+## Consequences
+
+- A component without a passing accessibility story doesn't ship. Stories include the Storybook a11y addon check as part of the definition of done.
+- Playwright CI fails on `axe-core` violations. Violations must be resolved or explicitly documented as accepted exceptions before merging.
+- Any accepted exception is noted here as an amendment with a rationale and a remediation plan.
+- The carousel on the current site is a P0 item. The replacement in the new build ships with keyboard controls, pause support, and a `prefers-reduced-motion` alternative from the start.

--- a/docs/adr/0003-security-posture.md
+++ b/docs/adr/0003-security-posture.md
@@ -1,0 +1,66 @@
+# ADR-0003: Security posture
+
+Date: 2026-06-29
+Status: Accepted
+
+## Context
+
+Andrew works in information security. A personal portfolio with weak security hygiene would be a credibility problem for someone in that role. The target audience includes security-aware hiring managers at enterprise tech companies who will notice things like missing security headers or permissive CSP directives.
+
+The site is also a demonstration of craft. The same discipline applied to accessibility and token architecture applies here.
+
+## Decision
+
+### HTTP security headers
+
+All pages ship a strict set of security headers via a `_headers` file in the Cloudflare Pages output:
+
+- `Content-Security-Policy` — strict policy with nonces for any inline scripts. SvelteKit's `handle` hook generates nonces per request. No `unsafe-inline`, no `unsafe-eval`. External sources are allowlisted explicitly and minimally.
+- `Strict-Transport-Security` — long `max-age`, `includeSubDomains`.
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Permissions-Policy` — camera, microphone, geolocation, and payment denied by default.
+
+### Supply chain
+
+- `package-lock.json` is committed and CI uses `npm ci`, not `npm install`.
+- `npm audit` runs in CI and fails on high or critical severity findings. Moderate and low findings are reviewed manually.
+- Before adding a new dependency, its project health is evaluated using OpenSSF Scorecard (`scorecard.dev`). Scorecard checks branch protection, signed releases, active maintenance, dependency update tooling, and CI presence, and returns a numeric score. This is the adoption-decision gate. Scores are not committed to the repo — they decay as upstream projects evolve, and the live API is always more accurate. If a low-scoring package is accepted anyway, the rationale is documented as an amendment to this ADR, not as a score file.
+- The `ossf/scorecard-action` GitHub Action runs on a schedule and uploads results to GitHub's Security tab as SARIF. This surfaces drift in existing dependencies without requiring committed artifacts.
+- The Socket GitHub App runs on every PR that touches `package.json`. It clones the registry in real time and flags new install scripts, outbound network requests, environment variable access, and obfuscated code within seconds of publication. This catches supply chain attacks that haven't yet made it into CVE databases. Socket is free for public repositories.
+- Third-party runtime dependencies are kept minimal. Replacing Bootstrap and FontAwesome SVG+JS with bespoke CSS and inline SVG removes two external runtime code sources that would otherwise require CSP allowlist entries and introduce supply chain risk.
+- No third-party analytics, tracking pixels, or session recording scripts. If analytics are added later, the choice must be documented here and the CSP updated accordingly.
+
+### Accepted Scorecard exceptions
+
+- **MDsvex** (`pngwn/mdsvex`) scored 3.1, with a Maintained score of 0. The project isn't actually abandoned — the last commit predates this check by about a week — but Scorecard's maintenance check measures commit/issue velocity, which a small, stable preprocessor doesn't need. Accepted because it's a build-time-only dependency: a compromised version affects the build machine and CI runner, not site visitors. Socket's PR-time scanning is the mitigating control. It's also the only tool that lets Svelte components render inside Markdown, which is why ADR-0009 chose it. See ADR-0009.
+- **Terrazzo** (`terrazzoapp/terrazzo`) scored 5.3. Maintained: 10 and every critical check (Dangerous-Workflow, License, CI-Tests, Code-Review) passes; the gaps are process hygiene (no security policy, unpinned CI dependencies, no token-permissions restrictions) typical of a smaller, newer project. Accepted because it's the only Vite-native DTCG build tool, which is why ADR-0006 chose it. See ADR-0006.
+
+### Contact form Worker
+
+- Bot protection runs server-side in the Worker before any processing occurs. Submitting to the form endpoint directly, bypassing the client-side form, doesn't bypass the protection.
+- Rate limiting is enforced in the Worker independently from any email provider limits. Excessive requests from a single IP are rejected before reaching the email delivery step.
+- User input is validated and sanitized in the Worker. The email provider only receives clean, bounded data.
+- Worker credentials are environment variables in the Cloudflare dashboard. Nothing sensitive is in the repo.
+
+### No persistent client-side storage
+
+- No cookies are set without a clear, documented purpose.
+- No `localStorage` or `sessionStorage` is used.
+- No user data is collected or stored anywhere in this stack.
+
+## Alternatives considered
+
+**Looser CSP with `unsafe-inline`.** Easier to set up with SvelteKit's default inline script approach. Not acceptable here. `unsafe-inline` is a meaningful XSS risk and a poor signal on a security professional's site. Nonce-based CSP takes more initial setup but is the right posture.
+
+**Third-party analytics** (Fathom, Plausible, etc.). Both are privacy-preserving options worth considering if page view data becomes useful. The default is no analytics. Any addition requires updating the CSP and documenting the decision here.
+
+**Client-side bot protection.** Moving the bot protection check to the browser (via a client-side widget) makes it bypassable by anyone who submits directly to the Worker endpoint. Server-side validation is the only layer that actually holds.
+
+## Consequences
+
+- Adding any third-party script in the future requires a CSP update and a documented justification. This is a forcing function, not a bureaucratic hurdle.
+- The security posture is testable: security headers can be verified in Playwright E2E tests and audited with tools like Mozilla Observatory.
+- `npm audit` failures block CI. The team (one person) is responsible for resolving or explicitly accepting findings before merging.
+- The contact form Worker needs rate limiting logic written explicitly. Cloudflare's built-in rate limiting rules can supplement the Worker-level check.

--- a/docs/adr/0004-framework-sveltekit.md
+++ b/docs/adr/0004-framework-sveltekit.md
@@ -1,0 +1,31 @@
+# ADR-0004: Framework: SvelteKit over Eleventy
+
+Date: 2026-06-29
+Status: Accepted
+
+## Context
+
+The site was built on Eleventy v3 (rebranded to Build Awesome in March 2026). The stack included Bootstrap 5 for styles and Nunjucks for templates. Both were overdue for replacement.
+
+The main goals for a new stack: a real component model for building a design system, first-class TypeScript, and a Storybook integration where the same component files the site uses are what Storybook renders. Eleventy's Nunjucks template model doesn't satisfy any of those. Templates aren't components; they can't be rendered interactively in Storybook.
+
+## Decision
+
+Use SvelteKit with `adapter-cloudflare`. All pages are prerendered at build time. Server-side logic runs in Cloudflare Workers and is scoped to the contact form.
+
+## Alternatives considered
+
+**Eleventy (Build Awesome v4).** Still maintained with full backwards compatibility. But Nunjucks templates aren't interactive components, so Storybook support would be marginal at best. The Build Awesome rebrand under Font Awesome also raised questions about long-term direction.
+
+**Astro.** The dominant SSG in 2026. Strong choice for content-first sites, zero JS by default. The problem: `.astro` files are server-rendered HTML templates, not reactive components. Storybook renders them as static HTML snapshots with no interactivity. Building a real design system in Astro means writing components in a second framework (Svelte or React) as islands, then wrapping them in `.astro` pages. That's two component models for one project.
+
+**TanStack Start.** Good type safety and an official Storybook integration in Storybook 10.4. Designed for app-shaped problems: dashboards, SaaS, full-stack data flows. A personal portfolio is a content-shaped problem. Most of the TanStack stack (Query, Form, Table, Virtual) wouldn't be used.
+
+## Consequences
+
+- Svelte 5 runes are the reactivity model. Components use `$props()`, `$state()`, `$derived()`.
+- All routes under `src/routes/` prerender to static HTML. No SSR on demand except the contact form Worker.
+- SvelteKit scoped styles handle component-level CSS. Global styles use `@layer` (see ADR-0007).
+- MDsvex is added as a preprocessor to allow Svelte components inside portfolio case study Markdown files (see ADR-0009).
+- The three-tier token architecture uses base, semantic, and component tiers (see ADR-0006).
+- Replacing Bootstrap + FontAwesome SVG+JS with bespoke CSS and inline SVG removes two sources of third-party runtime code. Fewer external scripts means a narrower attack surface and a stricter Content Security Policy (see ADR-0003).

--- a/docs/adr/0005-hosting-cloudflare.md
+++ b/docs/adr/0005-hosting-cloudflare.md
@@ -1,0 +1,32 @@
+# ADR-0005: Hosting: Cloudflare Pages + Workers
+
+Date: 2026-06-29
+Status: Accepted
+
+## Context
+
+The site was hosted on Netlify. The domain is registered at Cloudflare, which means Cloudflare is already the DNS provider. Netlify was an extra vendor in the chain with no benefit over going directly to Cloudflare Pages.
+
+The site is otherwise static. The one server-side requirement is a contact form that sends email without exposing an address in the HTML.
+
+## Decision
+
+Deploy to Cloudflare Pages via `adapter-cloudflare`. Handle the contact form with a Cloudflare Worker that validates submissions with a bot protection service and delivers email via a transactional email provider.
+
+## Alternatives considered
+
+**Stay on Netlify with Netlify Forms.** Netlify Forms handles the contact form with near-zero setup, just an HTML attribute. The free tier now includes unlimited form submissions (changed April 2026). The downside: Netlify's free bandwidth cap is ~15 GB/month and the site goes offline with no grace period if that's exceeded. Having the domain at Cloudflare and the site at Netlify also means managing two vendors when one covers both.
+
+**`adapter-static` instead of `adapter-cloudflare`.** Pure static output, host-agnostic. No Workers support, so the contact form would need a third-party service. Using `adapter-cloudflare` keeps the contact form native to the stack while still prerendering everything at build time.
+
+**A third-party form service** (Formspark, Splitforms, etc.). Works on any host. Adds a vendor dependency for functionality that a single Worker handles without one.
+
+## Consequences
+
+- DNS, CDN, and hosting are all in the same Cloudflare dashboard as the domain.
+- Static asset requests are free and unlimited on Cloudflare Pages. No bandwidth cap.
+- The contact form is a SvelteKit form action backed by a Worker. It works without JavaScript (progressive enhancement built in).
+- The contact form uses a bot protection service integrated at the Worker level, not the client form layer, so it can't be bypassed by submitting the form endpoint directly.
+- Rate limiting is enforced in the Worker independently of the email provider. Excessive requests from a single IP are rejected before they reach the email delivery step.
+- Email delivery is handled by a transactional email provider via API call inside the Worker. Credentials are environment variables in the Cloudflare dashboard, not in the repo.
+- HTTP security headers are configured via a `_headers` file in the Cloudflare Pages output. See ADR-0003 for the full header policy.

--- a/docs/adr/0006-token-architecture.md
+++ b/docs/adr/0006-token-architecture.md
@@ -1,0 +1,37 @@
+# ADR-0006: Design tokens: three-tier DTCG via Terrazzo
+
+Date: 2026-06-29
+Status: Accepted
+
+## Context
+
+Bootstrap 5 used Sass variables for design values. They compile away at build time and aren't accessible at runtime. The goal is a token pipeline that mirrors how Andrew's employer's design system is built: DTCG-format JSON, a build tool that generates CSS custom properties, runtime-accessible values that can be inspected in DevTools.
+
+## Decision
+
+Tokens are defined in DTCG-format JSON under `tokens/`. Terrazzo runs as a Vite plugin (`@terrazzo/vite`) and generates CSS custom properties during the build. The generated CSS is imported in SvelteKit's root layout.
+
+Three tiers:
+
+**Base tokens.** Raw values, named for what they are. `color.pink.500 = #d42274`, `color.gray.900 = #212529`, `space.3 = 1.125rem`. Nothing in components should reference a base token directly.
+
+**Semantic tokens.** Named for their role. `color.brand.primary → color.pink.500`, `color.text.default → color.gray.900`. Components consume semantic tokens via CSS custom properties: `var(--color-brand-primary)`.
+
+**Component tokens.** Named for their specific usage. `button.primary.background → color.brand.primary`, `card.border-color → color.border.subtle`. Used inside component `<style>` blocks.
+
+## Alternatives considered
+
+**Two-tier (no base layer).** Semantic tokens point directly to raw values: `color.brand.primary = #d42274`. Simpler with a small palette. Works at this scale. But it skips demonstrating why the base layer exists: changing `color.pink.500` from `#d42274` to a new value should update every semantic and component token that references it automatically. The base layer is what makes that work.
+
+**Sass variables (Bootstrap approach).** Compile-time only. Not accessible at runtime. Can't be inspected in DevTools. Don't work with the CSS `color-scheme` property or any runtime theming.
+
+**CSS custom properties written by hand.** Works but isn't the production design system architecture this portfolio demonstrates. Also loses Terrazzo's type checking and DTCG spec compliance.
+
+## Consequences
+
+- Token JSON lives at `tokens/tokens.json`. It's the source of truth for all design values.
+- Terrazzo generates CSS custom properties into `src/lib/tokens/tokens.css`, imported in `src/routes/+layout.svelte`.
+- Changing a base token value propagates through every semantic and component token that references it.
+- The DTCG spec hit v1.0 stable in October 2025. The format is finalized.
+- Terrazzo's Vite plugin means tokens regenerate automatically during `vite dev` when the token JSON changes.
+- Terrazzo scored 5.3 on OpenSSF Scorecard, low enough to require the exception process described in ADR-0003. Accepted as a documented exception there.

--- a/docs/adr/0007-css-layers.md
+++ b/docs/adr/0007-css-layers.md
@@ -1,0 +1,41 @@
+# ADR-0007: CSS architecture: @layer
+
+Date: 2026-06-29
+Status: Accepted
+
+## Context
+
+Bootstrap handled cascade management through carefully tuned specificity across its component system. Without Bootstrap, that problem needs an explicit solution. Without one, global styles and Svelte scoped styles will conflict in unpredictable ways as the component library grows.
+
+## Decision
+
+Global CSS uses named `@layer` blocks with an explicit cascade order declared upfront:
+
+```css
+@layer reset, tokens, base, components, utilities;
+```
+
+**`reset`.** Minimal CSS reset. Sets `box-sizing: border-box`, removes default margins, handles `font-family` inheritance. Nothing opinionated.
+
+**`tokens`.** Terrazzo output. CSS custom properties on `:root`. Custom properties don't participate in the cascade, but including them in the layer order makes the architecture readable.
+
+**`base`.** Base HTML element styles. `body` font settings from DESIGN.md, heading scale, `<a>` defaults, blockquote treatment.
+
+**`components`.** Global component styles that can't live in Svelte scoped styles. Rare.
+
+**`utilities`.** Utility classes, if any are needed. Kept minimal; Svelte scoped styles handle component-specific overrides.
+
+Svelte scoped styles are not in a layer. They automatically win over any layered global style without needing high specificity. That's the right default: a component's own styles should beat global base styles.
+
+## Alternatives considered
+
+**No layers, manage specificity manually.** Works for small projects. Breaks down as global styles and the component library grow. The mental overhead isn't worth it.
+
+**Tailwind CSS.** Utility-first approach that sidesteps the cascade by avoiding global styles almost entirely. Doesn't fit a project where the design system and its token pipeline are the artifact. Bespoke CSS using generated custom properties is a better demonstration of the architecture.
+
+## Consequences
+
+- `@layer` is supported in all modern browsers.
+- The cascade order is explicit and auditable. Any developer reading the root CSS file can see which layer wins.
+- Adding new global styles means deciding which layer they belong to, which is a useful forcing function.
+- Bootstrap specificity quirks are gone. There's no framework-level specificity to fight.

--- a/docs/adr/0008-component-model.md
+++ b/docs/adr/0008-component-model.md
@@ -1,0 +1,35 @@
+# ADR-0008: Component model: src/lib + Storybook + Chromatic
+
+Date: 2026-06-29
+Status: Accepted
+
+## Context
+
+The portfolio is meant to demonstrate design system ownership at a principal level, not just describe it. The components that make up the site should be documented, isolated, accessible, testable, and visually regression-tested. That requires a component library structure and a story-based development workflow.
+
+## Decision
+
+Components live in `src/lib/components/`. Routes consume them. Storybook runs against the same files. Chromatic publishes the Storybook and runs visual regression on every push.
+
+Two categories belong in `src/lib/`:
+
+**Primitive components.** Content-agnostic UI. Button, Card, Badge, form inputs. Would make sense in any Svelte project. All get stories.
+
+**Content components.** Know about portfolio data shapes but appear in more than one route. ResumeEntry, TestimonialQuote, PortfolioCard. These also get stories, with representative example data.
+
+Page sections (Hero, Nav, Footer) are route-specific. They live in `src/routes/` and don't get stories. The line: if a component could be dropped into a different Svelte project and still make sense, it goes in `src/lib/`. If it only makes sense in the context of this portfolio, it stays in routes.
+
+## Alternatives considered
+
+**Monorepo with a separate design system package.** Adds package resolution, publish steps, and version management for a project with one consumer. Not worth the overhead at this scale.
+
+**Storybook as local-only dev tooling.** No public URL, no visual regression. The design system work becomes invisible to people evaluating the portfolio. It defeats the purpose.
+
+**Self-hosted Storybook on a Cloudflare Pages subdomain** (e.g., `design.andrewpucci.com`). Same cost as Chromatic ($0). Requires building visual regression tooling separately. Chromatic provides that for free on the open source plan.
+
+## Consequences
+
+- The Storybook URL is a deliverable, not just a dev tool. It's linkable from the portfolio.
+- Chromatic free tier is 5,000 snapshots/month. The repo is public and likely qualifies for the open source plan, which has unlimited snapshots.
+- Visual regression runs on every push via GitHub Actions + Chromatic CI.
+- A component without a story has no behavioral tests (see ADR-0010).

--- a/docs/adr/0009-content-modeling.md
+++ b/docs/adr/0009-content-modeling.md
@@ -1,0 +1,30 @@
+# ADR-0009: Content modeling
+
+Date: 2026-06-29
+Status: Accepted
+
+## Context
+
+The site has two types of content with different needs. Resume entries, speaking history, and education records are structured, short, and frontmatter-heavy. Portfolio case studies are narrative-driven and benefit from rich, interactive content when the subject is the design system itself.
+
+## Decision
+
+**Structured content** (resume entries, speaking, education, volunteering, portfolio card metadata, author info): plain Markdown with frontmatter, loaded at build time via `import.meta.glob()`. TypeScript interfaces define the schema. Validated at build time, not runtime.
+
+**Portfolio case studies**: MDsvex. Allows Svelte components to be embedded directly inside Markdown. A case study can include a live component demo, a before/after interaction, or an interactive accessibility example pulled from `src/lib/`. The case study demonstrates the work rather than just describing it.
+
+## Alternatives considered
+
+**Plain Markdown for everything.** Simpler. Sufficient for the resume. Not sufficient for case studies that should show the design system in context.
+
+**A headless CMS** (Contentful, Sanity, etc.). Adds an external dependency, credentials to manage, and API calls at build time for content that changes a few times a year. The content lives just as well in the repo.
+
+**Astro Content Collections.** Zod-validated, type-safe schemas for content with automatic type inference. The right choice if the project were in Astro. Not available in SvelteKit, so TypeScript interfaces with `import.meta.glob()` do the same job.
+
+## Consequences
+
+- MDsvex is added as a preprocessor in `svelte.config.js`. Case study pages use the `.svx` or `.md` extension depending on whether they embed components.
+- `import.meta.glob()` loads structured Markdown files at build time. Frontmatter is typed against TypeScript interfaces in `src/lib/types/`.
+- Any component in `src/lib/` can be imported and rendered inside a case study page. This is the main payoff of choosing MDsvex over plain Markdown.
+- Resume entries and other structured data stay simple: one Markdown file per entry, frontmatter fields match the TypeScript interface.
+- MDsvex scored 3.1 on OpenSSF Scorecard, low enough to require the exception process described in ADR-0003. Accepted as a documented exception there.

--- a/docs/adr/0010-testing-strategy.md
+++ b/docs/adr/0010-testing-strategy.md
@@ -1,0 +1,35 @@
+# ADR-0010: Testing strategy
+
+Date: 2026-06-29
+Status: Accepted
+
+## Context
+
+The existing Eleventy site used Vitest for unit tests and Playwright for E2E. Adding Storybook introduces a third option: `@storybook/test` interaction tests that live inside story files and run via Vitest. The question is whether to maintain a separate Vitest component test layer alongside Storybook stories, or let the stories be the tests.
+
+## Decision
+
+Three-layer testing stack:
+
+**Vitest.** Pure utility functions in `src/lib/utils/`. No component rendering. Date formatting, token helpers, content processing, frontmatter parsing utilities.
+
+**Storybook interaction tests.** Component behavior, keyboard navigation, ARIA state changes, interactive states. Written as `play()` functions inside story files. Run in CI via Vitest's Storybook project integration. This is the component testing layer. There is no separate Vitest component test layer.
+
+**Playwright.** Full E2E flows: page navigation, contact form submission end-to-end, page structure, and accessibility at the page level via `@axe-core/playwright`. Axe runs on every page route and fails CI on any violation. See ADR-0002.
+
+**Lighthouse.** Performance, Core Web Vitals, best practices, and SEO gates on every deployment. Enforces the usability thresholds defined in ADR-0001. Run via the `lighthouse` CLI directly in a GitHub Actions step — not via `@lhci/cli`, which scored 3.7 on OpenSSF Scorecard and hasn't had a commit to main since June 2025. The core `lighthouse` package (GoogleChrome/lighthouse) is actively maintained, scored 6.7, and includes a CLI with JSON output suitable for threshold assertion.
+
+## Alternatives considered
+
+**Vitest component tests alongside Storybook stories.** Maintaining both means writing each component twice: once as a story for visual documentation and once as a test for behavioral assertions. Most of what a component test would assert is already expressed in the story. Redundant.
+
+**Playwright for everything.** E2E tests can cover component behavior, but they're slow and don't integrate with Chromatic's visual regression pipeline. Better as the last layer, not the only layer.
+
+## Consequences
+
+- A component without a story has no behavioral tests. Stories are the contract.
+- Visual regression coverage comes from Chromatic on every push. No separate visual testing tool needed.
+- CI runs two test suites: Vitest (utility functions and Storybook interaction tests) and Playwright (E2E flows). Same shape as before, different coverage distribution.
+- The 80% coverage threshold from the previous Vitest config carries forward, now spanning utility functions and interaction tests.
+- `npm audit` runs in CI and fails on high or critical severity findings. See ADR-0003.
+- Lighthouse runs on every deployment via the `lighthouse` CLI and enforces the thresholds defined in ADR-0001.


### PR DESCRIPTION
## Summary
- Add `CONTEXT.md` with the project's domain vocabulary (tokens, Terrazzo, MDsvex, Storybook/Chromatic, CSS layers, Cloudflare Workers, etc.)
- Add 10 ADRs recording the decision to move from Eleventy/Nunjucks/Bootstrap/Netlify to SvelteKit/Cloudflare/Terrazzo/Storybook, plus the usability, accessibility, security, and testing standards the new build commits to
- Fix a handful of cross-doc inconsistencies caught in review: a wrong WCAG citation (2.4.11 → 1.4.11) in ADR-0002, an "adoption gate" referenced in ADR-0006/0009 that ADR-0003 never actually defines a number for, a naming clash between ADR-0001's "Lighthouse CI" and ADR-0010's explicit rejection of `@lhci/cli`, and inconsistent MDsvex/MDsveX capitalization

## Test plan
- [ ] N/A — documentation only, no code changes